### PR TITLE
Zalando/openjdk memory helper script

### DIFF
--- a/Dockerfiles/Cassandra-2/cassandra-env.sh
+++ b/Dockerfiles/Cassandra-2/cassandra-env.sh
@@ -312,4 +312,7 @@ JVM_OPTS="$JVM_OPTS $MX4J_ADDRESS"
 JVM_OPTS="$JVM_OPTS $MX4J_PORT"
 JVM_OPTS="$JVM_OPTS $JVM_EXTRA_OPTS"
 
+# zalando-stups/docker-openjdk helper script
+JVM_OPTS="$JVM_OPTS $(java-dynamic-memory-opts)"
+
 cassandra_storagedir="${CASSANDRA_DATA_DIR}/data"

--- a/Dockerfiles/Cassandra-3.0.x/cassandra-env.sh
+++ b/Dockerfiles/Cassandra-3.0.x/cassandra-env.sh
@@ -318,4 +318,7 @@ JVM_OPTS="$JVM_OPTS $MX4J_ADDRESS"
 JVM_OPTS="$JVM_OPTS $MX4J_PORT"
 JVM_OPTS="$JVM_OPTS $JVM_EXTRA_OPTS"
 
+# zalando-stups/docker-openjdk helper script
+JVM_OPTS="$JVM_OPTS $(java-dynamic-memory-opts)"
+
 cassandra_storagedir="${CASSANDRA_DATA_DIR}/data"

--- a/Dockerfiles/Cassandra-3/cassandra-env.sh
+++ b/Dockerfiles/Cassandra-3/cassandra-env.sh
@@ -291,4 +291,7 @@ JVM_OPTS="$JVM_OPTS $MX4J_ADDRESS"
 JVM_OPTS="$JVM_OPTS $MX4J_PORT"
 JVM_OPTS="$JVM_OPTS $JVM_EXTRA_OPTS"
 
+# zalando-stups/docker-openjdk helper script
+JVM_OPTS="$JVM_OPTS $(java-dynamic-memory-opts)"
+
 cassandra_storagedir="${CASSANDRA_DATA_DIR}/data"


### PR DESCRIPTION
Hi, guys.

Does it make sense to reuse `zalando-stups/docker-openjdk` `java-dynamic-memory-opts` script?

We encountered several issues, when not all available memory was allocated for the cassandra jvm and nodes just crashed during scaling or `nodetool repair` operations (which is extremely frustrating).

Adding this script increased available memory usage in our case.