### PR TITLE
Add TimeWindowCompactionStrategy to 3.0.x docker image

### DIFF
--- a/Dockerfiles/Cassandra-3.0.x/Dockerfile
+++ b/Dockerfiles/Cassandra-3.0.x/Dockerfile
@@ -12,9 +12,16 @@ RUN echo "deb http://www.apache.org/dist/cassandra/debian 30x main" | tee -a /et
 RUN curl https://www.apache.org/dist/cassandra/KEYS | apt-key add -
 
 RUN apt-get -y update && apt-get -y -o Dpkg::Options::='--force-confold' --fix-missing dist-upgrade
-RUN apt-get -y install vim less sysstat \
+RUN apt-get -y install vim less sysstat maven \
     cassandra=$CASSIE_VERSION \
     cassandra-tools=$CASSIE_VERSION && \
+    twcs_commit=0543c3f6c122a521fea65b3a719245ea62bb705c && \
+    curl -sL https://github.com/jeffjirsa/twcs/archive/${twcs_commit}.tar.gz | tar xz -C /usr/src && \
+    cd /usr/src/twcs-${twcs_commit}/TimeWindowCompactionStrategy && \
+    mvn package && \
+    mv target/TimeWindowCompactionStrategy-3.0.0.jar /usr/share/cassandra/lib/ && \
+    rm -rf target ~/.m2 && \
+    apt-get -y remove maven && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 

--- a/Dockerfiles/Cassandra-3.0.x/Dockerfile
+++ b/Dockerfiles/Cassandra-3.0.x/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get -y install vim less sysstat maven \
     mv target/TimeWindowCompactionStrategy-3.0.0.jar /usr/share/cassandra/lib/ && \
     rm -rf target ~/.m2 && \
     apt-get -y remove maven && \
+    apt-get -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
We will need this for migration from 2.1 (via 2.2).