### PR TITLE
Add support for overriding environment in update command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -185,6 +185,7 @@ Available options for update:
 --instance-type      The type of instance to deploy each node on (e.g. t2.medium)
 --scalyr-key         API Key for writing logs to Scalyr (optional).
 --scalyr-region      Scalyr account region, such as 'eu' (optional).
+--environment, -e    Extend/override environment section of Taupage user data.
 --sns-topic          Amazon SNS topic name to use for notifications about Auto-Recovery.
 --sns-email          Email address to subscribe to Amazon SNS notification topic.  See description of ``create`` subcommand above for details.
 ===================  ========================================================

--- a/planb/cli.py
+++ b/planb/cli.py
@@ -142,6 +142,7 @@ def extend(from_region: str,
 @click.option('--instance-type', type=str)
 @click.option('--scalyr-region')
 @click.option('--scalyr-key')
+@click.option('--environment', '-e', multiple=True)
 @click.option('--sns-topic', help=sns_topic_help)
 @click.option('--sns-email', help=sns_email_help)
 def update(cluster_name: str,
@@ -153,12 +154,9 @@ def update(cluster_name: str,
            instance_type: str,
            scalyr_region: str,
            scalyr_key: str,
+           environment: list,
            sns_topic: str,
            sns_email: str):
-
-    if not(docker_image or taupage_ami_id):
-        msg = "Please specify at least one of --docker-image or --taupage-ami-id"
-        raise click.UsageError(msg)
 
     update_cluster(options=locals())
 

--- a/planb/common.py
+++ b/planb/common.py
@@ -250,3 +250,7 @@ def ensure_instance_profile(cluster_name: str):
     if profile is None:
         profile = create_instance_profile(cluster_name)
     return profile
+
+
+def environment_as_dict(environment: list) -> dict:
+    return dict(map(lambda x: x.split("=", 1), environment))

--- a/planb/create_cluster.py
+++ b/planb/create_cluster.py
@@ -24,7 +24,7 @@ from .common import boto_client, list_instances, \
     override_ephemeral_block_devices, \
     get_user_data, dump_user_data_for_taupage, \
     setup_sns_topics_for_alarm, create_auto_recovery_alarm, \
-    ensure_instance_profile
+    ensure_instance_profile, environment_as_dict
 
 
 def find_security_group_by_name(ec2: object, sg_name: str) -> dict:
@@ -677,21 +677,9 @@ def validate_artifact_version(options: dict) -> dict:
     return dict(options, docker_image=docker_image, image_version=image_version)
 
 
-def read_environment(options: dict) -> dict:
-    if options['environment']:
-        return dict(
-            options,
-            environment=dict(
-                map(lambda x: x.split("=", 1), options['environment'])
-            )
-        )
-    else:
-        return options
-
-
 def create_cluster(options: dict):
     options = validate_artifact_version(options)
-    options = read_environment(options)
+    options['environment'] = environment_as_dict(options.get('environment', []))
 
     keystore, truststore = generate_certificate(options['cluster_name'])
 
@@ -805,7 +793,7 @@ def extend_cluster(options: dict):
 
     # TODO: don't override docker image?
     options = validate_artifact_version(options)
-    options = read_environment(options)
+    options['environment'] = environment_as_dict(options.get('environment', []))
 
     # List of IP addresses by region
     node_ips = collections.defaultdict(list)

--- a/planb/update_cluster.py
+++ b/planb/update_cluster.py
@@ -15,7 +15,7 @@ from .common import boto_client, \
     dump_user_data_for_taupage, list_instances, \
     override_ephemeral_block_devices, get_user_data, \
     setup_sns_topics_for_alarm, create_auto_recovery_alarm, \
-    ensure_instance_profile
+    ensure_instance_profile, environment_as_dict
 
 
 """
@@ -285,6 +285,13 @@ def build_run_instances_params(
     if docker_image:
         user_data_changes['source'] = docker_image
 
+    environment = options.get('environment')
+    if environment:
+        user_data_changes['environment'] = dict(
+            params['UserData'].get('environment', {}),
+            **environment
+        )
+
     scalyr_region = options.get('scalyr_region')
     if scalyr_region:
         user_data_changes['scalyr_region'] = scalyr_region
@@ -519,6 +526,7 @@ def update_cluster(options: dict):
     else:
         alarm_topics = {}
     options = dict(options, alarm_topics=alarm_topics)
+    options['environment'] = environment_as_dict(options.get('environment', []))
 
     # TODO: List all nodes with IPs and some status information
     for i in instances:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,9 @@
+import pytest
+
+from planb.common import environment_as_dict
+
+
+def test_environment_as_dict():
+    raw_list = ["key=value", "base64=dGVzdA=="]
+    expected = {'key': 'value', 'base64': 'dGVzdA=='}
+    assert environment_as_dict(raw_list) == expected

--- a/tests/test_create_cluster.py
+++ b/tests/test_create_cluster.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import MagicMock
 
 from planb.create_cluster import generate_private_ip_addresses, \
-    IpAddressPoolDepletedException, read_environment
+    IpAddressPoolDepletedException
 
 
 def test_generate_private_ip_addresses():
@@ -56,10 +56,3 @@ def test_generate_private_ip_addresses():
         list(generate_private_ip_addresses(
                 ec2, [{'CidrBlock': '192.168.1.0/27'}], 21
             ))
-
-
-def test_read_environment():
-    raw_list = ["key=value", "base64=dGVzdA=="]
-    parsed_dict = {'key': 'value', 'base64': 'dGVzdA=='}
-    expected = {'environment': parsed_dict}
-    assert read_environment({'environment': raw_list}) == expected

--- a/tests/test_update_cluster.py
+++ b/tests/test_update_cluster.py
@@ -44,6 +44,10 @@ def test_build_run_instances_params():
                 '/var/lib/cassandra': {
                     'partition': '/dev/xvdf'
                 }
+            },
+            'environment': {
+                'key0': 'keepval0',
+                'key1': 'oldval1'
             }
         }
     }
@@ -52,6 +56,10 @@ def test_build_run_instances_params():
         'docker_image': 'docker.registry/cassandra:123',
         'taupage_ami_id': 'ami-654321',
         'instance_type': 'm4.xlarge',
+        'environment': {
+            'key1': 'value1',
+            'key2': 'value2'
+        },
         'scalyr_region': 'eu',
         'scalyr_key': 'new-shiny-scalyr-key'
     }
@@ -76,6 +84,11 @@ def test_build_run_instances_params():
                 '/var/lib/cassandra': {
                     'partition': '/dev/xvdf'
                 }
+            },
+            'environment': {
+                'key0': 'keepval0',
+                'key1': 'value1',
+                'key2': 'value2'
             },
             'scalyr_region': 'eu',
             'scalyr_account_key': 'new-shiny-scalyr-key'


### PR DESCRIPTION
* Extract environment_as_dict to common functions.
* Do not require docker image or taupage ami for update command