### PR TITLE
Include the DC suffix in the instance and volume name tags

### DIFF
--- a/planb/create_cluster.py
+++ b/planb/create_cluster.py
@@ -493,7 +493,11 @@ def launch_instance(region: str, ip: dict, ami: object, subnet: dict,
         mappings = ami.block_device_mappings
         block_devices = override_ephemeral_block_devices(mappings)
 
-        volume_name = '{}-{}'.format(options['cluster_name'], ip['PrivateIp'])
+        volume_name = '{}{}-{}'.format(
+            options['cluster_name'],
+            options['dc_suffix'],
+            ip['PrivateIp']
+        )
         create_tagged_volume(
             ec2,
             options,
@@ -523,7 +527,10 @@ def launch_instance(region: str, ip: dict, ami: object, subnet: dict,
 
         ec2.create_tags(
             Resources=[instance_id],
-            Tags=[{'Key': 'Name', 'Value': options['cluster_name']}]
+            Tags=[{
+                'Key': 'Name',
+                'Value': options['cluster_name'] + options['dc_suffix']
+            }]
         )
         # wait for instance to initialize before we can assign a
         # public IP address to it or tag the attached volume

--- a/planb/show_cluster.py
+++ b/planb/show_cluster.py
@@ -1,4 +1,12 @@
+from clickclick import print_table
+
+TITLES = {
+    'NameTag': 'Name Tag',
+    'PrivateIpAddress': 'Private IP',
+}
+
 def show_instances(instances):
-    for i in instances:
-        f = "{InstanceId} {PrivateIpAddress}".format(**i)
-        print(f)
+    print_table(["NameTag", "PrivateIpAddress"],
+                [dict(i, NameTag=i['Tags']['Name'])
+                 for i in instances],
+                titles=TITLES)

--- a/planb/update_cluster.py
+++ b/planb/update_cluster.py
@@ -11,6 +11,7 @@ import os
 
 # TODO: can we avoid the explicit list here?
 from .common import boto_client, \
+    tags_as_dict, \
     dump_dict_as_file, load_dict_from_file, \
     dump_user_data_for_taupage, list_instances, \
     override_ephemeral_block_devices, get_user_data, \
@@ -51,10 +52,6 @@ def create_tags(ec2: object, resource_id: str, tags: dict):
         Tags=[{'Key': k, 'Value': v}
               for k, v in tags.items()]
     )
-
-
-def tags_as_dict(tags: list) -> dict:
-    return {t['Key']: t['Value'] for t in tags}
 
 
 def update_tags(ec2: object, resource_id: str, tags: dict):
@@ -501,12 +498,7 @@ def list_instances_to_update(ec2: object, cluster_name: str) -> list:
             return [saved_instance]
     else:
         print("Listing cluster nodes for {}".format(cluster_name))
-        alive_instances = [
-            i
-            for i in list_instances(ec2, cluster_name)
-            if 'PrivateIpAddress' in i
-        ]
-        return sorted(alive_instances, key=lambda i: i['PrivateIpAddress'])
+        return list_instances(ec2, cluster_name)
 
 
 def update_cluster(options: dict):
@@ -533,7 +525,10 @@ def update_cluster(options: dict):
         # TODO: user should hit Ctrl-c to cancel everything
         # don't ask again if resuming after crash
         if len(instances) > 1:
-            question = "Update node {}?".format(i['PrivateIpAddress'])
+            question = "Update node {} with IP {}?".format(
+                i['Tags']['Name'],
+                i['PrivateIpAddress']
+            )
             if not click.confirm(question):
                 continue
 


### PR DESCRIPTION
When listing nodes, sort by the name tag, then by the private IP address.
This will help operating on virtual DCs in isolation.

For operating on nodes of all DCs, it is still possible to use wildcards in
the cluster name parameter, i.e: 'mycluster*'.