### PR TITLE
Fix behavior of update command in presence of cluster name wildcards

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -191,6 +191,11 @@ Available options for update:
 --sns-email          Email address to subscribe to Amazon SNS notification topic.  See description of ``create`` subcommand above for details.
 ===================  ========================================================
 
+The cluster name parameter is used to list all EC2 instances in the region
+with the matching ``Name`` tag.  This parameter may contain wildcards (``*``).
+For example, if you have multiple virtual data centers in a cluster, this
+allows to update all nodes of all DCs by running only one command.
+
 Update is an interactive command which operates on one node at a time.
 It will prompt before starting update of each node.  It starts by draining the
 target node and then terminates the EC2 instance that is running it.  Then a new
@@ -202,10 +207,6 @@ node.  This keeps all the node's data and identification within the cluster inta
 The command will wait for the replacement node to be back UP.  You should still
 monitor the status of the cluster to verify that all other nodes also see the new
 node as UP before proceeding.
-
-The command will refuse to proceed if some nodes are DOWN.  This could be a false
-positive, however if some nodes were decommissioned recently (it takes about 72 hours
-for this state to clear).
 
 While performing the update, which destroys the running EC2 instance and creates a
 blank one, the command keeps the current state in the tags of the EBS data volume.

--- a/planb/common.py
+++ b/planb/common.py
@@ -54,6 +54,10 @@ def tags_as_dict(tags: list) -> dict:
     return {t['Key']: t['Value'] for t in tags}
 
 
+def select_keys(d: dict, keys: list):
+    return {k: v for k, v in d.items() if k in keys}
+
+
 def json_serial(obj):
     """JSON serializer for objects not serializable by default json code"""
 

--- a/planb/common.py
+++ b/planb/common.py
@@ -109,7 +109,7 @@ def list_instances(ec2: object, cluster_name: str):
         }
     ])
     all_instances = sum([r['Instances'] for r in resp['Reservations']], [])
-    return sorted([dict(i, Tags=tags_as_dict(i['Tags']))
+    return sorted([dict(i, Tags=tags_as_dict(i.get('Tags', [])))
                    for i in all_instances],
                   key=lambda i: (i['Tags']['Name'],
                                  netaddr.IPAddress(i['PrivateIpAddress'])))

--- a/planb/update_cluster.py
+++ b/planb/update_cluster.py
@@ -71,7 +71,8 @@ def get_instance(ec2: object, instance_id: str) -> dict:
         logger.error("Unexpected number of reservations for {}: {} != 1"
                      .format(instance_id, len(reservations)))
         return None
-    return reservations[0]['Instances'][0]
+    instance = reservations[0]['Instances'][0]
+    return dict(instance, Tags=tags_as_dict(instance.get('Tags', [])))
 
 
 def get_volume(ec2: object, volume_id: str) -> dict:
@@ -324,7 +325,7 @@ def configure_instance(ec2: object, volume: dict, saved_instance: dict,
         return
 
     instance_id = instance['InstanceId']
-    ec2.create_tags(Resources=[instance_id], Tags=saved_instance['Tags'])
+    create_tags(ec2, instance_id, saved_instance['Tags'])
 
     region = options['region']
     alarm_sns_topic_arn = None

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,9 +1,21 @@
 import pytest
 
-from planb.common import environment_as_dict
+from planb.common import environment_as_dict, tags_as_dict, select_keys
 
 
 def test_environment_as_dict():
     raw_list = ["key=value", "base64=dGVzdA=="]
     expected = {'key': 'value', 'base64': 'dGVzdA=='}
     assert environment_as_dict(raw_list) == expected
+
+
+def test_tags_as_dict():
+    taglist = [{'Key': 'key1', 'Value': 'val1'},
+               {'Key': 'key2', 'Value': 'val2'}]
+    tagdict = {'key1': 'val1',
+               'key2': 'val2'}
+    assert tags_as_dict(taglist) == tagdict
+
+
+def test_select_keys():
+    assert select_keys({'a': 1, 'b': 2, 'c': 3}, ['a', 'c']) == {'a': 1, 'c': 3}

--- a/tests/test_update_cluster.py
+++ b/tests/test_update_cluster.py
@@ -1,18 +1,14 @@
 from unittest.mock import MagicMock
-from planb.update_cluster import select_keys, tags_as_dict, \
-    get_user_data, build_run_instances_params
+from planb.update_cluster import get_volume_name_tag, get_user_data, \
+    build_run_instances_params
 
 
-def test_select_keys():
-    assert select_keys({'a': 1, 'b': 2, 'c': 3}, ['a', 'c']) == {'a': 1, 'c': 3}
-
-
-def test_tags_as_dict():
-    taglist = [{'Key': 'key1', 'Value': 'val1'},
-               {'Key': 'key2', 'Value': 'val2'}]
-    tagdict = {'key1': 'val1',
-               'key2': 'val2'}
-    assert tags_as_dict(taglist) == tagdict
+def test_volume_name_tag():
+    instance = {
+        'PrivateIpAddress': '12.34',
+        'Tags': {'Name': 'my-cluster'}
+    }
+    assert get_volume_name_tag(instance) == 'my-cluster-12.34'
 
 
 def test_get_user_data():
@@ -37,7 +33,7 @@ def test_build_run_instances_params():
         'SubnetId': 'sn-123',
         'PrivateIpAddress': '172.31.128.11',
         'IamInstanceProfile': {'Arn': 'arn:barn', 'Id': '123'},
-        'Tags': [{'Key': 'Name', 'Value': 'my-cluster-name'}],
+        'Tags': {'Name': 'my-cluster-name'},
         'UserData': {
             'source': 'docker.registry/cassandra:101',
             'mounts': {
@@ -52,7 +48,7 @@ def test_build_run_instances_params():
         }
     }
     options = {
-        'cluster_name': 'my-cluster-name',
+        'cluster_name': 'my-cluster-name*',
         'docker_image': 'docker.registry/cassandra:123',
         'taupage_ami_id': 'ami-654321',
         'instance_type': 'm4.xlarge',
@@ -111,7 +107,7 @@ def test_preserve_original_scalyr_key():
         'SubnetId': 'sn-123',
         'PrivateIpAddress': '172.31.128.11',
         'IamInstanceProfile': {'Arn': 'arn:barn', 'Id': '123'},
-        'Tags': [{'Key': 'Name', 'Value': 'my-cluster-name'}],
+        'Tags': {'Name': 'my-cluster-name'},
         'UserData': {
             'source': 'docker.registry/cassandra:101',
             'mounts': {


### PR DESCRIPTION
Use instance name tag everywhere instead of cluster_name.  This might still
create additional instance profiles, per ring, but it's currently not clear
how to avoid that in general.