### PR TITLE
Bump Cassandra package versions to the latest released ones

### DIFF
--- a/Dockerfiles/Cassandra-2.2/Dockerfile
+++ b/Dockerfiles/Cassandra-2.2/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Zalando SE
 # SSL Storage Port, JMX, Jolokia Agent, CQL Native
 EXPOSE 7001 7199 8778 9042
 
-ENV CASSIE_VERSION=2.2.12
+ENV CASSIE_VERSION=2.2.13
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN echo "deb http://www.apache.org/dist/cassandra/debian 22x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list

--- a/Dockerfiles/Cassandra-3.0.x/Dockerfile
+++ b/Dockerfiles/Cassandra-3.0.x/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Zalando SE
 # SSL Storage Port, JMX, Jolokia Agent, CQL Native
 EXPOSE 7001 7199 8778 9042
 
-ENV CASSIE_VERSION=3.0.16
+ENV CASSIE_VERSION=3.0.17
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN echo "deb http://www.apache.org/dist/cassandra/debian 30x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list

--- a/Dockerfiles/Cassandra-3/Dockerfile
+++ b/Dockerfiles/Cassandra-3/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Zalando SE
 # SSL Storage Port, JMX, Jolokia Agent, CQL Native
 EXPOSE 7001 7199 8778 9042
 
-ENV CASSIE_VERSION=3.11.2
+ENV CASSIE_VERSION=3.11.3
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN echo "deb http://www.apache.org/dist/cassandra/debian 311x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list


### PR DESCRIPTION
The new versions are: 2.2.13, 3.0.17 and 3.11.3.