### PR TITLE
Fix Dockerfiles

### DIFF
--- a/Dockerfiles/Cassandra-2.2/Dockerfile
+++ b/Dockerfiles/Cassandra-2.2/Dockerfile
@@ -8,20 +8,16 @@ EXPOSE 7001 7199 8778 9042
 ENV CASSIE_VERSION=2.2.13
 ENV DEBIAN_FRONTEND=noninteractive
 
+RUN apt-get -y update && apt-get -y -o Dpkg::Options::='--force-confold' --fix-missing dist-upgrade
+RUN apt-get -y install apt-utils gnupg
+
 RUN echo "deb http://www.apache.org/dist/cassandra/debian 22x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list
 RUN curl https://www.apache.org/dist/cassandra/KEYS | apt-key add -
+RUN apt-get -y update
 
-RUN apt-get -y update && apt-get -y -o Dpkg::Options::='--force-confold' --fix-missing dist-upgrade
-RUN apt-get -y install vim less sysstat maven \
+RUN apt-get -y install vim less sysstat \
     cassandra=$CASSIE_VERSION \
     cassandra-tools=$CASSIE_VERSION && \
-    twcs_commit=19081e2b53b2bc273292c2820efd3b9d05226c53 && \
-    curl -sL https://github.com/jeffjirsa/twcs/archive/${twcs_commit}.tar.gz | tar xz -C /usr/src && \
-    cd /usr/src/twcs-${twcs_commit} && \
-    mvn package && \
-    mv target/TimeWindowCompactionStrategy-2.2.5.jar /usr/share/cassandra/lib/ && \
-    rm -rf target ~/.m2 && \
-    apt-get -y remove maven && \
     apt-get -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfiles/Cassandra-2/Dockerfile
+++ b/Dockerfiles/Cassandra-2/Dockerfile
@@ -8,20 +8,16 @@ EXPOSE 7001 7199 8778 9042
 ENV CASSIE_VERSION=2.1.20
 ENV DEBIAN_FRONTEND=noninteractive
 
+RUN apt-get -y update && apt-get -y -o Dpkg::Options::='--force-confold' --fix-missing dist-upgrade
+RUN apt-get -y install apt-utils gnupg
+
 RUN echo "deb http://www.apache.org/dist/cassandra/debian 21x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list
 RUN curl https://www.apache.org/dist/cassandra/KEYS | apt-key add -
+RUN apt-get -y update
 
-RUN apt-get -y update && apt-get -y -o Dpkg::Options::='--force-confold' --fix-missing dist-upgrade
-RUN apt-get -y install vim less sysstat maven \
+RUN apt-get -y install vim less sysstat \
     cassandra=$CASSIE_VERSION \
     cassandra-tools=$CASSIE_VERSION && \
-    twcs_commit=f6326a60746d4d5e01ba565427dd46de3df37806 && \
-    curl -sL https://github.com/jeffjirsa/twcs/archive/${twcs_commit}.tar.gz | tar xz -C /usr/src && \
-    cd /usr/src/twcs-${twcs_commit}/TimeWindowCompactionStrategy && \
-    mvn package && \
-    mv target/TimeWindowCompactionStrategy-2.1.12.jar /usr/share/cassandra/lib/ && \
-    rm -rf target ~/.m2 && \
-    apt-get -y remove maven && \
     apt-get -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfiles/Cassandra-3.0.x/Dockerfile
+++ b/Dockerfiles/Cassandra-3.0.x/Dockerfile
@@ -8,20 +8,16 @@ EXPOSE 7001 7199 8778 9042
 ENV CASSIE_VERSION=3.0.17
 ENV DEBIAN_FRONTEND=noninteractive
 
+RUN apt-get -y update && apt-get -y -o Dpkg::Options::='--force-confold' --fix-missing dist-upgrade
+RUN apt-get -y install apt-utils gnupg
+
 RUN echo "deb http://www.apache.org/dist/cassandra/debian 30x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list
 RUN curl https://www.apache.org/dist/cassandra/KEYS | apt-key add -
+RUN apt-get -y update
 
-RUN apt-get -y update && apt-get -y -o Dpkg::Options::='--force-confold' --fix-missing dist-upgrade
-RUN apt-get -y install vim less sysstat maven \
+RUN apt-get -y install vim less sysstat \
     cassandra=$CASSIE_VERSION \
     cassandra-tools=$CASSIE_VERSION && \
-    twcs_commit=10ee91c6f409aa249c8d439f7670d8b997ab0869 && \
-    curl -sL https://github.com/a1exsh/twcs/archive/${twcs_commit}.tar.gz | tar xz -C /usr/src && \
-    cd /usr/src/twcs-${twcs_commit}/TimeWindowCompactionStrategy && \
-    mvn package && \
-    mv target/TimeWindowCompactionStrategy-3.0.15.jar /usr/share/cassandra/lib/ && \
-    rm -rf target ~/.m2 && \
-    apt-get -y remove maven && \
     apt-get -y autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfiles/Cassandra-3/Dockerfile
+++ b/Dockerfiles/Cassandra-3/Dockerfile
@@ -8,10 +8,13 @@ EXPOSE 7001 7199 8778 9042
 ENV CASSIE_VERSION=3.11.3
 ENV DEBIAN_FRONTEND=noninteractive
 
+RUN apt-get -y update && apt-get -y -o Dpkg::Options::='--force-confold' --fix-missing dist-upgrade
+RUN apt-get -y install apt-utils gnupg
+
 RUN echo "deb http://www.apache.org/dist/cassandra/debian 311x main" | tee -a /etc/apt/sources.list.d/apache.cassandra.list
 RUN curl https://www.apache.org/dist/cassandra/KEYS | apt-key add -
+RUN apt-get -y update
 
-RUN apt-get -y update && apt-get -y -o Dpkg::Options::='--force-confold' --fix-missing dist-upgrade
 RUN apt-get -y install vim less sysstat \
     cassandra=$CASSIE_VERSION \
     cassandra-tools=$CASSIE_VERSION && \


### PR DESCRIPTION
* Add gnupg as a new implicit dependency of apt-key.  Previously it was
  provided, but now you have to install it manually.

* Remove custom-built TWCS jar.  We don't need this anymore and it is provided
  in 3.0+.  Also, docker build was broken because of maven.