### PR TITLE
Add setalarm subcommand

### DIFF
--- a/planb/alarm.py
+++ b/planb/alarm.py
@@ -1,0 +1,27 @@
+from .common import boto_client, get_instance, \
+    setup_sns_topics_for_alarm, create_auto_recovery_alarm
+
+
+def set_auto_recovery_alarm(options: dict):
+    region = options['region']
+
+    alarm_sns_topic_arn = None
+    if options['sns_topic'] or options['sns_email']:
+        regions = [region]
+        alarm_topics = setup_sns_topics_for_alarm(
+            regions,
+            options['sns_topic'],
+            options['sns_email']
+        )
+        alarm_sns_topic_arn = alarm_topics[region]
+
+    ec2 = boto_client('ec2', region)
+    instance_id = options['instance_id']
+    instance = get_instance(ec2, instance_id)
+
+    create_auto_recovery_alarm(
+        region,
+        instance['Tags']['Name'],
+        instance_id,
+        alarm_sns_topic_arn
+    )

--- a/planb/cli.py
+++ b/planb/cli.py
@@ -6,6 +6,7 @@ from .common import boto_client, list_instances
 from .show_cluster import show_instances
 from .create_cluster import create_cluster, extend_cluster
 from .update_cluster import update_cluster
+from .alarm import set_auto_recovery_alarm
 from .remote_command import run_shell, run_nodetool, run_cqlsh
 
 
@@ -168,6 +169,19 @@ def update(cluster_name: str,
            sns_email: str):
 
     update_cluster(options=locals())
+
+
+@cli.command()
+@click.option('--region', type=str, required=True)
+@click.option('--instance-id', type=str, required=True)
+@click.option('--sns-topic', help=sns_topic_help)
+@click.option('--sns-email', help=sns_email_help)
+def setalarm(region: str,
+             instance_id: str,
+             sns_topic: str,
+             sns_email: str):
+
+    set_auto_recovery_alarm(options=locals())
 
 
 @cli.command()

--- a/planb/common.py
+++ b/planb/common.py
@@ -115,6 +115,17 @@ def list_instances(ec2: object, cluster_name: str):
                                  netaddr.IPAddress(i['PrivateIpAddress'])))
 
 
+def get_instance(ec2: object, instance_id: str) -> dict:
+    resp = ec2.describe_instances(InstanceIds=[instance_id])
+    reservations = resp['Reservations']
+    if len(reservations) != 1:
+        logger.error("Unexpected number of reservations for {}: {} != 1"
+                     .format(instance_id, len(reservations)))
+        return None
+    instance = reservations[0]['Instances'][0]
+    return dict(instance, Tags=tags_as_dict(instance.get('Tags', [])))
+
+
 def override_ephemeral_block_devices(mappings: dict) -> dict:
     #
     # Override any ephemeral volumes with NoDevice mapping,

--- a/planb/update_cluster.py
+++ b/planb/update_cluster.py
@@ -13,7 +13,7 @@ import os
 from .common import boto_client, \
     tags_as_dict, select_keys, \
     dump_dict_as_file, load_dict_from_file, \
-    dump_user_data_for_taupage, list_instances, \
+    dump_user_data_for_taupage, get_instance, list_instances, \
     override_ephemeral_block_devices, get_user_data, \
     setup_sns_topics_for_alarm, create_auto_recovery_alarm, \
     ensure_instance_profile, environment_as_dict
@@ -62,17 +62,6 @@ def set_error_state(ec2: object, volume: dict, message: str):
         ec2, volume['VolumeId'],
         {'planb:operation:state': 'failed', 'planb:update:fail-reason': message}
     )
-
-
-def get_instance(ec2: object, instance_id: str) -> dict:
-    resp = ec2.describe_instances(InstanceIds=[instance_id])
-    reservations = resp['Reservations']
-    if len(reservations) != 1:
-        logger.error("Unexpected number of reservations for {}: {} != 1"
-                     .format(instance_id, len(reservations)))
-        return None
-    instance = reservations[0]['Instances'][0]
-    return dict(instance, Tags=tags_as_dict(instance.get('Tags', [])))
 
 
 def get_volume(ec2: object, volume_id: str) -> dict:


### PR DESCRIPTION
Add a separate command to create auto-recovery alarm.  This is useful when adding more nodes manually to scale out the cluster.