### PR TITLE
Fix location of GC logs

### DIFF
--- a/Dockerfiles/Cassandra-2.2/cassandra-env.sh
+++ b/Dockerfiles/Cassandra-2.2/cassandra-env.sh
@@ -245,7 +245,7 @@ JVM_OPTS="$JVM_OPTS -XX:+PrintPromotionFailure"
 # JVM_OPTS="$JVM_OPTS -Xloggc:/var/log/cassandra/gc-`date +%s`.log"
 # If you are using JDK 6u34 7u2 or later you can enable GC log rotation
 # don't stick the date in the log name if rotation is on.
-JVM_OPTS="$JVM_OPTS -Xloggc:${CASSANDRA_HOME}/logs/gc.log"
+JVM_OPTS="$JVM_OPTS -Xloggc:${CASSANDRA_DATA_DIR}/logs/gc.log"
 JVM_OPTS="$JVM_OPTS -XX:+UseGCLogFileRotation"
 JVM_OPTS="$JVM_OPTS -XX:NumberOfGCLogFiles=10"
 JVM_OPTS="$JVM_OPTS -XX:GCLogFileSize=10M"

--- a/Dockerfiles/Cassandra-2/cassandra-env.sh
+++ b/Dockerfiles/Cassandra-2/cassandra-env.sh
@@ -244,7 +244,7 @@ JVM_OPTS="$JVM_OPTS -XX:+PrintPromotionFailure"
 # JVM_OPTS="$JVM_OPTS -Xloggc:/var/log/cassandra/gc-`date +%s`.log"
 # If you are using JDK 6u34 7u2 or later you can enable GC log rotation
 # don't stick the date in the log name if rotation is on.
-JVM_OPTS="$JVM_OPTS -Xloggc:${CASSANDRA_HOME}/logs/gc.log"
+JVM_OPTS="$JVM_OPTS -Xloggc:${CASSANDRA_DATA_DIR}/logs/gc.log"
 JVM_OPTS="$JVM_OPTS -XX:+UseGCLogFileRotation"
 JVM_OPTS="$JVM_OPTS -XX:NumberOfGCLogFiles=10"
 JVM_OPTS="$JVM_OPTS -XX:GCLogFileSize=10M"

--- a/Dockerfiles/Cassandra-3.0.x/cassandra-env.sh
+++ b/Dockerfiles/Cassandra-3.0.x/cassandra-env.sh
@@ -122,7 +122,7 @@ case "$jvm" in
 esac
 
 #GC log path has to be defined here because it needs to access CASSANDRA_HOME
-JVM_OPTS="$JVM_OPTS -Xloggc:${CASSANDRA_HOME}/logs/gc.log"
+JVM_OPTS="$JVM_OPTS -Xloggc:${CASSANDRA_DATA_DIR}/logs/gc.log"
 
 # Here we create the arguments that will get passed to the jvm when
 # starting cassandra.

--- a/Dockerfiles/Cassandra-3/cassandra-env.sh
+++ b/Dockerfiles/Cassandra-3/cassandra-env.sh
@@ -122,7 +122,7 @@ case "$jvm" in
 esac
 
 #GC log path has to be defined here because it needs to access CASSANDRA_HOME
-JVM_OPTS="$JVM_OPTS -Xloggc:${CASSANDRA_HOME}/logs/gc.log"
+JVM_OPTS="$JVM_OPTS -Xloggc:${CASSANDRA_DATA_DIR}/logs/gc.log"
 
 # Here we create the arguments that will get passed to the jvm when
 # starting cassandra.


### PR DESCRIPTION
Turns out that `$CASSANDRA_HOME` is set to `/usr/share/cassandra`, use
`$CASSANDRA_DATA_DIR` instead.