### PR TITLE
Update logback pattern for better logging

### DIFF
--- a/Dockerfiles/Cassandra-2.2/logback.xml
+++ b/Dockerfiles/Cassandra-2.2/logback.xml
@@ -3,7 +3,7 @@
   
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%-5level %date{HH:mm:ss,SSS} %msg%n</pattern>
+      <pattern>%date{ISO8601} %-5level %msg%n</pattern>
     </encoder>
   </appender>
   

--- a/Dockerfiles/Cassandra-2/logback.xml
+++ b/Dockerfiles/Cassandra-2/logback.xml
@@ -3,7 +3,7 @@
   
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%-5level %date{HH:mm:ss,SSS} %msg%n</pattern>
+      <pattern>%date{ISO8601} %-5level %msg%n</pattern>
     </encoder>
   </appender>
   

--- a/Dockerfiles/Cassandra-3.0.x/logback.xml
+++ b/Dockerfiles/Cassandra-3.0.x/logback.xml
@@ -3,7 +3,7 @@
   
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%-5level %date{HH:mm:ss,SSS} %msg%n</pattern>
+      <pattern>%date{ISO8601} %-5level %msg%n</pattern>
     </encoder>
   </appender>
   

--- a/Dockerfiles/Cassandra-3/logback.xml
+++ b/Dockerfiles/Cassandra-3/logback.xml
@@ -3,7 +3,7 @@
   
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%-5level %date{HH:mm:ss,SSS} %msg%n</pattern>
+      <pattern>%date{ISO8601} %-5level %msg%n</pattern>
     </encoder>
   </appender>
   


### PR DESCRIPTION
1. Fix timestamp format to include date and milliseconds.
2. Put timestamp first for convenience.