### PR TITLE
Preserve Enhanced instance monitoring setting on update

### DIFF
--- a/planb/update_cluster.py
+++ b/planb/update_cluster.py
@@ -239,6 +239,9 @@ def build_run_instances_params(
     mappings = override_ephemeral_block_devices(image['BlockDeviceMappings'])
     params['BlockDeviceMappings'] = mappings
 
+    if saved_instance.get('Monitoring', {}).get('State') == 'enabled':
+        params['Monitoring'] = {'Enabled': True}
+
     user_data_changes = {
         'volumes': {
             'ebs': {

--- a/tests/test_update_cluster.py
+++ b/tests/test_update_cluster.py
@@ -34,6 +34,9 @@ def test_build_run_instances_params():
         'PrivateIpAddress': '172.31.128.11',
         'IamInstanceProfile': {'Arn': 'arn:barn', 'Id': '123'},
         'Tags': {'Name': 'my-cluster-name'},
+        'Monitoring': {
+            'State': 'enabled'
+        },
         'UserData': {
             'source': 'docker.registry/cassandra:101',
             'mounts': {
@@ -70,6 +73,7 @@ def test_build_run_instances_params():
         'PrivateIpAddress': '172.31.128.11',
         'BlockDeviceMappings': [],
         'IamInstanceProfile': {'Arn': 'arn:barn'},
+        'Monitoring': {'Enabled': True},
         'UserData': {
             'source': 'docker.registry/cassandra:123',
             'volumes': {


### PR DESCRIPTION
By default Enhanced monitoring is disabled.  When updating an EC2 instance on
which this was manually enabled, carry the setting over from the saved
instance.