### PR TITLE
Change how we use piu for remote commands

### DIFF
--- a/planb/cli.py
+++ b/planb/cli.py
@@ -228,10 +228,10 @@ def nodes(region: str, cluster_name: str, filters: list):
 @cli.group()
 @click.option('--region', type=str, required=True)
 @click.option('--odd-host', '-O', type=str, required=True)
+@click.option('--piu', type=str, required=True, help="Run piu first with this parameter as reason.")
 @click.option('--cluster-name', type=str, required=True)
 @click.option('--filters', type=str, default="[]", callback=validate_filters,
               required=False, help=filters_help)
-@click.option('--piu', type=str, help="Run piu first with this parameter as reason.")
 @click.option('--echo', is_flag=True, help="Print the ssh command before running it.")
 @click.option('--no-prompt', is_flag=True, help="Don't prompt before running the ssh command.")
 @click.option('--no-wait', is_flag=True, help="Don't wait for the ssh command to exit.")

--- a/planb/remote_command.py
+++ b/planb/remote_command.py
@@ -19,10 +19,11 @@ def run_on_instance(
         piu_cmd = ['piu', 'request-access', '--odd-host', odd_host, ip, piu]
         subprocess.check_call(piu_cmd)
 
-    inner_ssh_cmd = 'ssh -o StrictHostKeyChecking=no {} {}'.format(
-        ip, quoted(' '.join(command))
+    outer_ssh_cmd = 'ssh -o StrictHostKeyChecking=no -J odd@{} ubuntu@{} {}'.format(
+        odd_host,
+        ip,
+        quoted(' '.join(command))
     )
-    outer_ssh_cmd = 'ssh -tA {} {}'.format(odd_host, quoted(inner_ssh_cmd))
     if echo:
         print("-"*len(outer_ssh_cmd))
         print(outer_ssh_cmd)


### PR DESCRIPTION
We expect that the latest version of piu is installed and that the EC2
instances are updated to support EC2 Instance Connect.  The `--piu` parameter
with the reason is now required.